### PR TITLE
Make the Haskell and Storybook sidebar examples more similar.

### DIFF
--- a/Hypered/Html.hs
+++ b/Hypered/Html.hs
@@ -92,14 +92,17 @@ document Config{..} path title body = do
           [ cStaticPath </> fontCss cFont
           , cStaticPath </> "css/tachyons.min.v4.11.1.css"
           , cStaticPath </> "css/style.css"
+          , cStaticPath </> "css/styles.css"
           ]
 
     H.body ! A.class_ (H.toValue (fontClass cFont)) $
-      H.div ! A.class_ "mw8 center pa4 lh-copy" $
+      H.div ! A.class_ "flex flex-column justify-between min-height-vh-100 mw8 center pa4 lh-copy" $
         body
 
 nav content =
-  H.nav ! A.class_ "flex align-items-center lh-copy mb4 pv3" $ content
+  H.nav ! A.class_ "flex justify-between align-items-center lh-copy mb4 pv3" $
+    H.div $
+      content
 
 -- | Horizontal navigation at the top of a page.
 navigation :: FilePath -> Html
@@ -126,14 +129,14 @@ navigation path = do
 -- wrapper and footer.
 navigationNoteed =
   H.header $
-    H.nav ! A.class_ "flex align-items-center lh-copy mb4 pv3" $ do
+    nav $ do
       H.a ! A.class_ "link mr3 black hover-blue" ! A.href "#" $ "noteed.com"
       H.a ! A.class_ "link mr3 black hover-blue" ! A.href "#" $ "blog"
       H.a ! A.class_ "link mr3 black hover-blue" ! A.href "#" $ "not-os"
 
 navigationTemplate =
   H.header $
-    H.nav ! A.class_ "flex align-items-center lh-copy mb4 pv3" $ do
+    nav $ do
       "$for(nav)$"
       H.a ! A.class_ "link mr3 black hover-blue" ! A.href "$nav.href$" $
         "$nav.name$"

--- a/Hypered/Html.hs
+++ b/Hypered/Html.hs
@@ -204,38 +204,57 @@ codeBlock = H.pre ! A.class_ "pre overflow-auto" $ H.code $
 
 title = H.title "Hypered"
 
+sidebarTitle content =
+  H.h3 ! A.class_ "f5 ttu mv1" $ content
+
+sidebarUL content =
+  H.ul ! A.class_ "list pl0 mb3 mt0" $ content
+
+sidebarLI content =
+  H.li content
+
+sidebarLink content href =
+  H.a ! A.class_ "link black hover-blue" ! A.href href $ content
+
+sidebar xs =
+  H.aside ! A.class_ "order-2 order-0-m order-0-l w-100 w-20-m w-20-l ph3 mt2" $
+    H.nav $ do
+      mapM_ f xs
+
+  where
+
+  f (title, links) = do
+    sidebarTitle title
+    sidebarUL $
+      mapM_ g links
+  g (name, href) =
+    sidebarLI $
+      sidebarLink name href
+
 exampleSidebar = do
   navigationNoteed
-  H.main $ do
-    H.div ! A.class_ "flex flex-wrap nl3 nr3" $ do
-      H.nav ! A.class_ "order-1 order-0-m order-0-l w-100 w-25-m w-25-l pv3 ph3" $ do
-        H.h3 ! A.class_ "f5 ttu mv1" $ "Intro"
-        H.ul ! A.class_ "list pl0 mb3 mt0" $ do
-          H.li $ H.a ! A.class_ "link black hover-blue" ! A.href "#" $ "not-os"
-        H.h3 ! A.class_ "f5 ttu mv1" $ "Notes"
-        H.ul ! A.class_ "list pl0 mb3 mt0" $ do
-          H.li $ H.a ! A.class_ "link black hover-blue" ! A.href "#" $ "Digital Ocean"
-          H.li $ H.a ! A.class_ "link black hover-blue" ! A.href "#" $ "TODO"
-        H.h3 ! A.class_ "f5 ttu mv1" $ "Values"
-        H.ul ! A.class_ "list pl0 mb3 mt0" $ do
-          H.li $ H.a ! A.class_ "link black hover-blue" ! A.href "#" $ "command-line"
-          H.li $ H.a ! A.class_ "link black hover-blue" ! A.href "#" $ "root-modules"
-      H.section ! A.class_ "order-0 order-1-m order-1-l w-100 w-75-m w-75-l ph3" $
-        H.article $ do
-          H.h1 ! A.class_ "f1 lh-title mv2 tracked-tight" $ "not-os"
-          H.p ! A.class_ "f5 lh-copy mv3" $ do
-            "not-os is a minimal OS based on the Linux kernel, coreutils,"
-            "runit, and Nix. It is also the build script, written in Nix"
-            "expressions, to build such OS."
-          H.p ! A.class_ "f5 lh-copy mv3" $ do
-            "This is a project of Michael Bishop (cleverca22 on GitHub, clever on"
-            "IRC). I modified it just a bit to make it possible to generate this"
-            "documentation."
-          H.p ! A.class_ "f5 lh-copy mv3" $ do
-            "As a build tool, not-os uses nixpkgs and in particular the"
-            "NixOS module system"
-            "to build the three main components of a Linux-based operating"
-            "system:"
+  H.main ! A.class_ "flex flex-wrap nl3 nr3" $ do
+    sidebar
+      [ ("Intro", [("not-os", "#")])
+      , ("Notes", [("Digital Ocean", "#"), ("TODO", "#")])
+      , ("Values", [("command-line", "#"), ("root-modules", "#")])
+      ]
+    H.section ! A.class_ "order-0 order-1-m order-1-l w-100 w-75-m w-75-l ph3" $
+      H.article $ do
+        H.h1 ! A.class_ "f1 lh-title mv2 tracked-tight" $ "not-os"
+        H.p ! A.class_ "f5 lh-copy mv3" $ do
+          "not-os is a minimal OS based on the Linux kernel, coreutils,"
+          "runit, and Nix. It is also the build script, written in Nix"
+          "expressions, to build such OS."
+        H.p ! A.class_ "f5 lh-copy mv3" $ do
+          "This is a project of Michael Bishop (cleverca22 on GitHub, clever on"
+          "IRC). I modified it just a bit to make it possible to generate this"
+          "documentation."
+        H.p ! A.class_ "f5 lh-copy mv3" $ do
+          "As a build tool, not-os uses nixpkgs and in particular the"
+          H.a ! A.href "https://nixos.wiki/wiki/NixOS_Modules" $ "NixOS module system"
+          "to build the three main components of a Linux-based operating"
+          "system:"
   footer
 
 exampleSidePanel = do

--- a/Hypered/Html.hs
+++ b/Hypered/Html.hs
@@ -95,7 +95,7 @@ document Config{..} path title body = do
           ]
 
     H.body ! A.class_ (H.toValue (fontClass cFont)) $
-      H.div ! A.class_ "mw9 center ph4 lh-copy" $
+      H.div ! A.class_ "mw8 center pa4 lh-copy" $
         body
 
 nav content =
@@ -123,8 +123,8 @@ navigation path = do
         ]
 
 navigationNoteed =
-  H.header ! A.class_ "flex mb4" $
-    H.nav ! A.class_ "flex align-items-center lh-copy" $ do
+  H.header $
+    H.nav ! A.class_ "flex align-items-center lh-copy mb4 pv3" $ do
       H.a ! A.class_ "link mr3 black hover-blue" ! A.href "#" $ "noteed.com"
       H.a ! A.class_ "link mr3 black hover-blue" ! A.href "#" $ "blog"
       H.a ! A.class_ "link mr3 black hover-blue" ! A.href "#" $ "not-os"
@@ -204,7 +204,7 @@ codeBlock = H.pre ! A.class_ "pre overflow-auto" $ H.code $
 
 title = H.title "Hypered"
 
-exampleSidebar = H.div ! A.class_  "mw8 center pa4 lh-copy" $ do
+exampleSidebar = do
   navigationNoteed
   H.main $ do
     H.div ! A.class_ "flex flex-wrap nl3 nr3" $ do
@@ -227,9 +227,18 @@ exampleSidebar = H.div ! A.class_  "mw8 center pa4 lh-copy" $ do
             "not-os is a minimal OS based on the Linux kernel, coreutils,"
             "runit, and Nix. It is also the build script, written in Nix"
             "expressions, to build such OS."
+          H.p ! A.class_ "f5 lh-copy mv3" $ do
+            "This is a project of Michael Bishop (cleverca22 on GitHub, clever on"
+            "IRC). I modified it just a bit to make it possible to generate this"
+            "documentation."
+          H.p ! A.class_ "f5 lh-copy mv3" $ do
+            "As a build tool, not-os uses nixpkgs and in particular the"
+            "NixOS module system"
+            "to build the three main components of a Linux-based operating"
+            "system:"
   footer
 
-exampleSidePanel = H.div ! A.class_ "mw8 center pa4 lh-copy" $ do
+exampleSidePanel = do
   navigationNoteed
   H.main $ do
     H.div ! A.class_ "flex flex-wrap nl3 nr3" $ do
@@ -237,8 +246,8 @@ exampleSidePanel = H.div ! A.class_ "mw8 center pa4 lh-copy" $ do
         H.article $ do
           H.h1 ! A.class_ "f1 lh-title mv2 tracked-tight" $ "Waveguide"
           H.p ! A.class_ "f5 lh-copy mv3" $ do
-            "If neither a list of attribute names or a command are given, "
-            "Waveguide instrospects the Nix expression and builds all the "
+            "If neither a list of attribute names or a command are given,"
+            "Waveguide instrospects the Nix expression and builds all the"
             "found attributes."
       H.aside ! A.class_ "w-100 w-20-m w-20-l ph3 mt0 mt5-m mt5-l" $
         H.div ! A.class_ "nl3 nr3" $ do

--- a/Hypered/Html.hs
+++ b/Hypered/Html.hs
@@ -131,6 +131,14 @@ navigationNoteed =
       H.a ! A.class_ "link mr3 black hover-blue" ! A.href "#" $ "blog"
       H.a ! A.class_ "link mr3 black hover-blue" ! A.href "#" $ "not-os"
 
+navigationTemplate =
+  H.header $
+    H.nav ! A.class_ "flex align-items-center lh-copy mb4 pv3" $ do
+      "$for(nav)$"
+      H.a ! A.class_ "link mr3 black hover-blue" ! A.href "$nav.href$" $
+        "$nav.name$"
+      "$endfor$"
+
 -- | Content wrapper, for a blog post, at the same level as navigation and
 -- footer.
 wrapPost title content =
@@ -156,10 +164,10 @@ wrap content = do
       content
 
 -- | The footer, at the same level as both navigation and wrap.
-footer =
+footer content =
   H.footer ! A.class_ "pv4" $
     H.p ! A.class_ "inline-flex bt b--black-50 pt4 lh-copy" $
-      "© Võ Minh Thu, 2017-2019."
+      content
 
 
 -- | The main content, as a left column.
@@ -274,7 +282,7 @@ exampleSidebar = do
           H.a ! A.href "https://nixos.wiki/wiki/NixOS_Modules" $ "NixOS module system"
           "to build the three main components of a Linux-based operating"
           "system:"
-  footer
+  footer "© Võ Minh Thu, 2017-2019."
 
 exampleSidePanel = do
   navigationNoteed
@@ -301,4 +309,4 @@ exampleSidePanel = do
               H.a ! A.class_ "link no-underline black blue-hover" $ "→ #004"
             H.li ! A.class_ "pv1 bb b--black-10" $
               H.a ! A.class_ "link no-underline black blue-hover" $ "→ #005"
-  footer
+  footer "© Võ Minh Thu, 2017-2019."

--- a/Hypered/Html.hs
+++ b/Hypered/Html.hs
@@ -122,12 +122,31 @@ navigation path = do
         , ("README.html",             "About")
         ]
 
+-- | Horizontal navigation at the top of a page, at the same level as main
+-- wrapper and footer.
 navigationNoteed =
   H.header $
     H.nav ! A.class_ "flex align-items-center lh-copy mb4 pv3" $ do
       H.a ! A.class_ "link mr3 black hover-blue" ! A.href "#" $ "noteed.com"
       H.a ! A.class_ "link mr3 black hover-blue" ! A.href "#" $ "blog"
       H.a ! A.class_ "link mr3 black hover-blue" ! A.href "#" $ "not-os"
+
+-- | Content wrapper, for a blog post, at the same level as navigation and
+-- footer.
+wrapPost title content =
+  H.main $
+    H.article ! A.class_ "mw7" $ do
+      H.div ! A.class_ "mb4" $ do
+        H.h1 ! A.class_ "f1 lh-title mv2 tracked-tight" $
+          title
+        -- TODO
+        -- The example /storybook/iframe.html?id=layouts--blog-post has this rule:
+        --   H.hr ! A.class_ "mt3 pb3 bt-0 bl-0 br-0 bb b--black"
+        -- But it currently conflicts with the custome style.css that makes the
+        -- rule short and a bit thick.
+        --   H.hr
+        -- I'll have to ask Andy how to achieve both in the same document.
+      content
 
 -- | The main content wrapper, at the same level as navigation.
 wrap :: Html -> Html

--- a/README.md
+++ b/README.md
@@ -137,6 +137,37 @@ $ nix-shell -p nodejs --run 'node render-components footer'
 ```
 
 
+## Pandoc
+
+A Pandoc template can be generated with the `bin/hypered-templates.hs` script.
+
+To render Markdown files to HTML, Pandoc can be used as follow:
+
+```
+$ pandoc --template templates/default.html -M title=README README.md
+```
+
+This renders this `README.md` file as a standalone HTML page using the
+`default.html` templates. It fills the template `$title$` variable with the
+string `"README"`. (See
+https://pandoc.org/MANUAL.html#using-variables-in-templates for details.)
+
+To use the templates provided by this design system, some additional care
+should be taken, for instance to add the necessary Tachyons classes to headers
+(`h1`, `h2`, ...).
+
+Here is how the provided `pandoc/lua.md` example is rendered:
+
+```
+$ pandoc \
+  --standalone \
+  --template generated/templates/default.html \
+  --lua-filter pandoc/tachyons.lua \
+  --output docs/components/example--template.html \
+  pandoc/lua.md
+```
+
+
 ## Notes
 
 There is also a custom Revealjs template that (should) match the design-system.

--- a/README.md
+++ b/README.md
@@ -167,6 +167,9 @@ $ pandoc \
   pandoc/lua.md
 ```
 
+Note that the top horizontal navigation component is filled by using the
+document YAML metadata block (which can also be provided as a separate file).
+
 
 ## Notes
 

--- a/bin/hypered-guide.hs
+++ b/bin/hypered-guide.hs
@@ -28,7 +28,7 @@ main = do
   case args of
     [] -> generateGuide
     ["nav"] -> T.putStr (renderHtml (nav ""))
-    ["footer"] -> T.putStr (renderHtml footer)
+    ["footer"] -> T.putStr (renderHtml (footer "© Võ Minh Thu, 2017-2019."))
     _ -> error "Unsupported argument."
 
 
@@ -91,7 +91,8 @@ generateGuide = do
   -- Footer
 
   generate "footer.html" "Hypered style guide - Footer"
-    (const footer)
+    (const (footer "© Võ Minh Thu, 2017-2019."))
+
 
   -- Example usage
 

--- a/bin/hypered-templates.hs
+++ b/bin/hypered-templates.hs
@@ -9,8 +9,8 @@ import qualified Text.Blaze.Html5 as H
 import qualified Text.Blaze.Html5.Attributes as A
 
 import Hypered.Html
-  ( footer, navigation, navigationNoteed, title, partialHtml, prettyHtml, wrap
-  , wrapPost , Config(..), Font(Inter)
+  ( footer, navigation, navigationTemplate, title, partialHtml
+  , prettyHtml, wrap , wrapPost , Config(..), Font(Inter)
   )
 
 
@@ -20,19 +20,19 @@ config = Config "/static" Inter
 main :: IO ()
 main = do
   prettyHtml config "generated/templates" "default.html" "$title$"
-    (navigationNoteed >> wrapPost "$title$" "$body$" >> footer)
+    (navigationTemplate >> wrapPost "$title$" "$body$" >> footer "$footer$")
 
   -- TODO Currently reusing the default.html template.
   prettyHtml config "generated/templates" "default-2-cols.html" "$title$"
-    (wrap "$body$" >> footer)
+    (wrap "$body$" >> footer "$footer$")
 
   -- TODO Currently reusing the default.html template.
   prettyHtml config "generated/templates" "poster.html" "$title$"
-    (wrap "$body$" >> footer)
+    (wrap "$body$" >> footer "$footer$")
 
   -- We probably don't need the footer, navigation, and title partial
   -- templates since they can be generated with the complete templates.
 
-  partialHtml config "generated/templates" "footer.html" "" footer
+  partialHtml config "generated/templates" "footer.html" "" (footer "$footer$")
   partialHtml config "generated/templates" "navigation.html" "" (navigation ".")
   partialHtml config "generated/templates" "title.html" "" title

--- a/bin/hypered-templates.hs
+++ b/bin/hypered-templates.hs
@@ -9,8 +9,8 @@ import qualified Text.Blaze.Html5 as H
 import qualified Text.Blaze.Html5.Attributes as A
 
 import Hypered.Html
-  ( footer, navigation, title, partialHtml, prettyHtml, wrap
-  , Config(..), Font(Inter)
+  ( footer, navigation, navigationNoteed, title, partialHtml, prettyHtml, wrap
+  , wrapPost , Config(..), Font(Inter)
   )
 
 
@@ -20,7 +20,7 @@ config = Config "/static" Inter
 main :: IO ()
 main = do
   prettyHtml config "generated/templates" "default.html" "$title$"
-    (wrap "$body$" >> footer)
+    (navigationNoteed >> wrapPost "$title$" "$body$" >> footer)
 
   -- TODO Currently reusing the default.html template.
   prettyHtml config "generated/templates" "default-2-cols.html" "$title$"

--- a/bin/hypered-templates.hs
+++ b/bin/hypered-templates.hs
@@ -19,6 +19,9 @@ config = Config "/static" Inter
 ------------------------------------------------------------------------------
 main :: IO ()
 main = do
+  -- TODO The $body$ is indented when using the pretty printed, which
+  -- then causes Pandoc to indent part of <code> content, which
+  -- is wrong.
   prettyHtml config "generated/templates" "default.html" "$title$"
     (navigationTemplate >> wrapPost "$title$" "$body$" >> footer "$footer$")
 

--- a/bin/hypered-templates.hs
+++ b/bin/hypered-templates.hs
@@ -9,7 +9,7 @@ import qualified Text.Blaze.Html5 as H
 import qualified Text.Blaze.Html5.Attributes as A
 
 import Hypered.Html
-  ( footer, navigation, navigationTemplate, title, partialHtml
+  ( footer, generateHtml, navigation, navigationTemplate, title, partialHtml
   , prettyHtml, wrap , wrapPost , Config(..), Font(Inter)
   )
 
@@ -19,11 +19,12 @@ config = Config "/static" Inter
 ------------------------------------------------------------------------------
 main :: IO ()
 main = do
-  -- TODO The $body$ is indented when using the pretty printed, which
+  -- TODO The $body$ is indented when using the pretty printer, which
   -- then causes Pandoc to indent part of <code> content, which
-  -- is wrong.
-  prettyHtml config "generated/templates" "default.html" "$title$"
-    (navigationTemplate >> wrapPost "$title$" "$body$" >> footer "$footer$")
+  -- is wrong. Same for lots of white space betwee navigation links, which
+  -- causes also some additional "padding".
+  generateHtml config "generated/templates" "default.html" "$title$"
+    (H.div (navigationTemplate >> wrapPost "$title$" "$body$") >> footer "$footer$")
 
   -- TODO Currently reusing the default.html template.
   prettyHtml config "generated/templates" "default-2-cols.html" "$title$"

--- a/components/Layout/Layout.js
+++ b/components/Layout/Layout.js
@@ -6,16 +6,18 @@ function Layout(props) {
   return (
     <div className="flex flex-column justify-between min-height-vh-100 mw8 center pa4 lh-copy">
       <div>
-        <Nav>
-          <div>
-            <NavLink href="#" active={true}>
-              noteed.com
-            </NavLink>
-            <NavLink href="#">blog</NavLink>
-            <NavLink href="#">not-os</NavLink>
-          </div>
-        </Nav>
-      {props.children}
+        <header>
+          <Nav>
+            <div>
+              <NavLink href="#" active={true}>
+                noteed.com
+              </NavLink>
+              <NavLink href="#">blog</NavLink>
+              <NavLink href="#">not-os</NavLink>
+            </div>
+          </Nav>
+        </header>
+        {props.children}
       </div>
       <Footer></Footer>
     </div>

--- a/components/Nav/Nav.js
+++ b/components/Nav/Nav.js
@@ -2,6 +2,7 @@ import cx from "classnames";
 
 export const NavLink = React.forwardRef(function NavLink(props, ref) {
   let NavLinkClasses = cx("link", "black", "hover-blue", {
+    underline: props.active,
     mr3: !props.lastItem,
   });
 

--- a/components/Sidebar/Sidebar.js
+++ b/components/Sidebar/Sidebar.js
@@ -19,42 +19,30 @@ export const SidebarLink = props => (
 export const Sidebar = () => (
   <aside className="order-2 order-0-m order-0-l w-100 w-20-m w-20-l ph3 mt2">
     <nav>
-      <SidebarTitle>Section 1</SidebarTitle>
+      <SidebarTitle>Intro</SidebarTitle>
       <SidebarUL>
         <SidebarLI>
-          <SidebarLink href="#">Item One</SidebarLink>
-        </SidebarLI>
-        <SidebarLI>
-          <SidebarLink href="#">Item Two</SidebarLink>
-        </SidebarLI>
-        <SidebarLI>
-          <SidebarLink href="#">Item Three</SidebarLink>
+          <SidebarLink href="#">not-os</SidebarLink>
         </SidebarLI>
       </SidebarUL>
 
-      <SidebarTitle>Section 2</SidebarTitle>
+      <SidebarTitle>Notes</SidebarTitle>
       <SidebarUL>
         <SidebarLI>
-          <SidebarLink href="#">Item One</SidebarLink>
+          <SidebarLink href="#">Digital Ocean</SidebarLink>
         </SidebarLI>
         <SidebarLI>
-          <SidebarLink href="#">Item Two</SidebarLink>
-        </SidebarLI>
-        <SidebarLI>
-          <SidebarLink href="#">Item Three</SidebarLink>
+          <SidebarLink href="#">TODO</SidebarLink>
         </SidebarLI>
       </SidebarUL>
 
-      <SidebarTitle>Section 3</SidebarTitle>
+      <SidebarTitle>Values</SidebarTitle>
       <SidebarUL>
         <SidebarLI>
-          <SidebarLink href="#">Item One</SidebarLink>
+          <SidebarLink href="#">command-line</SidebarLink>
         </SidebarLI>
         <SidebarLI>
-          <SidebarLink href="#">Item Two</SidebarLink>
-        </SidebarLI>
-        <SidebarLI>
-          <SidebarLink href="#">Item Three</SidebarLink>
+          <SidebarLink href="#">root-modules</SidebarLink>
         </SidebarLI>
       </SidebarUL>
     </nav>

--- a/components/Sidebar/Sidebar.stories.js
+++ b/components/Sidebar/Sidebar.stories.js
@@ -8,7 +8,7 @@ export const Default = () => <Sidebar />;
 
 export const UsageExample = () => (
   <Layout>
-    <div className="flex flex-wrap nl3 nr3">
+    <main className="flex flex-wrap nl3 nr3">
       <Sidebar />
 
       <section className="order-0 order-1-m order-1-l w-100 w-75-m w-75-l ph3">
@@ -34,6 +34,6 @@ export const UsageExample = () => (
           </P>
         </article>
       </section>
-    </div>
+    </main>
   </Layout>
 );

--- a/pandoc/lua.md
+++ b/pandoc/lua.md
@@ -1,5 +1,13 @@
 ---
 title: Template
+nav:
+- name: noteed.com
+  href: "#"
+- name: blog
+  href: "#"
+- name: not-os
+  href: "#"
+footer: © Hypered SPRL, 2019.
 ---
 
 This is an example Markdown file to test the generated templates of the

--- a/pandoc/lua.md
+++ b/pandoc/lua.md
@@ -1,0 +1,14 @@
+---
+title: Template
+---
+
+This is an example Markdown file to test the generated templates of the
+[Hypered design system](https://github.com/hypered/design-system). In addition
+of the templates themselves, there are also Pandoc Lua filters to help format
+the final HTML.
+
+
+## Reference
+
+This page should match this [Storybook
+example](../storybook/iframe.html?id=layouts--blog-post).

--- a/pandoc/tachyons.lua
+++ b/pandoc/tachyons.lua
@@ -1,0 +1,13 @@
+-- This Pandoc Lua filter adds some Tachyons classes to headers (h1, h2, ...).
+-- Example usage:
+--
+--   pandoc --lua-filter tachyons.lua lua.md 
+
+function Header(elem)
+  if (elem.level == 1) then
+    elem.classes = {"f1", "lh-title", "mv2", "tracked-tight"}
+  elseif (elem.level == 2) then
+    elem.classes = {"f2", "lh-title", "mv2", "tracked-tight"}
+  end
+  return elem
+end


### PR DESCRIPTION
- Use mw8 instead of mw9 in Haskell,
- Remove the class on the header element in Haskell,
- Use the same text in the Haskell example,
- Use the same example links in the React example,
- In the sidebar story, use main instead of div, as done elsewhere,
- Remove the bold aspect when a nav link is active because it changes
its horizontal size and thus make the other links moves.

Hi @andyngo ,can you tell if you're ok with the two last points in particular, and other `.js` changes in general ?