### PR TITLE
Add space between nav

### DIFF
--- a/components/Layout/Layout.js
+++ b/components/Layout/Layout.js
@@ -6,11 +6,13 @@ function Layout(props) {
   return (
     <div className="mw8 center pa4 lh-copy">
       <Nav>
-        <NavLink href="#" active={true}>
-          Item 1
-        </NavLink>
-        <NavLink href="#">Item 2</NavLink>
-        <NavLink href="#">Item 3</NavLink>
+        <div>
+          <NavLink href="#" active={true}>
+            noteed.com
+          </NavLink>
+          <NavLink href="#">blog</NavLink>
+          <NavLink href="#">not-os</NavLink>
+        </div>
       </Nav>
       {props.children}
       <Footer></Footer>

--- a/components/Nav/Nav.js
+++ b/components/Nav/Nav.js
@@ -1,9 +1,12 @@
+import cx from "classnames";
+
 export const NavLink = React.forwardRef(function NavLink(props, ref) {
+  let NavLinkClasses = cx("link", "black", "hover-blue", {
+    mr3: !props.lastItem,
+  });
+
   return (
-    <a
-      className={`link mr3 black hover-blue${props.active ? " fw7" : " fw5"}`}
-      {...props}
-    >
+    <a className={NavLinkClasses} {...props}>
       {props.children}
     </a>
   );

--- a/components/Nav/Nav.js
+++ b/components/Nav/Nav.js
@@ -10,7 +10,7 @@ export const NavLink = React.forwardRef(function NavLink(props, ref) {
 });
 
 export const Nav = props => (
-  <nav className="flex align-items-center lh-copy mb4 pv3">
+  <nav className="flex justify-between align-items-center lh-copy mb4 pv3">
     {props.children}
   </nav>
 );

--- a/components/Nav/Nav.stories.js
+++ b/components/Nav/Nav.stories.js
@@ -6,10 +6,24 @@ export default {
 
 export const Navigation = () => (
   <Nav>
-    <NavLink href="#" active={true}>
-      Item 1
-    </NavLink>
-    <NavLink href="#">Item 2</NavLink>
-    <NavLink href="#">Item 3</NavLink>
+    <div>
+      <NavLink href="#" active={true}>
+        noteed.com
+      </NavLink>
+      <NavLink href="#">blog</NavLink>
+      <NavLink href="#">not-os</NavLink>
+    </div>
+  </Nav>
+);
+
+export const NavigationSpaceBetween = () => (
+  <Nav>
+    <div>
+      <NavLink href="#">noteed.com</NavLink>
+    </div>
+    <div>
+      <NavLink href="#">blog</NavLink>
+      <NavLink href="#">not-os</NavLink>
+    </div>
   </Nav>
 );

--- a/components/Nav/Nav.stories.js
+++ b/components/Nav/Nav.stories.js
@@ -23,7 +23,9 @@ export const NavigationSpaceBetween = () => (
     </div>
     <div>
       <NavLink href="#">blog</NavLink>
-      <NavLink href="#">not-os</NavLink>
+      <NavLink href="#" lastItem={true}>
+        not-os
+      </NavLink>
     </div>
   </Nav>
 );

--- a/components/home/ComponentsSection.js
+++ b/components/home/ComponentsSection.js
@@ -299,9 +299,11 @@ export const ComponentsSection = props => (
 
       <Gallery title="Nav" href="#">
         <Nav>
-          <NavLink active={"true"}>One</NavLink>
-          <NavLink>Two</NavLink>
-          <NavLink>Three</NavLink>
+	  <div>
+            <NavLink active={"true"}>One</NavLink>
+            <NavLink>Two</NavLink>
+            <NavLink>Three</NavLink>
+	  </div>
         </Nav>
       </Gallery>
     </div>

--- a/components/home/NavSection.js
+++ b/components/home/NavSection.js
@@ -18,8 +18,10 @@ const NavItem = withRouter(({ children, href, router }) => {
 
 const NavSection = props => (
   <Nav>
-    <NavItem href="/">Home</NavItem>
-    <NavItem href="/components">Components</NavItem>
+    <div>
+      <NavItem href="/">Home</NavItem>
+      <NavItem href="/components">Components</NavItem>
+    </div>
   </Nav>
 );
 


### PR DESCRIPTION
PR for the following request/issue: https://github.com/hypered/design-system/issues/21

`Nav` has `justify: space-between` by default now. This means that you will need to wrap `<NavLink>` with a `<div>` to properly space the items in `Nav`.

Example:
```
<nav className="flex justify-between align-items-center lh-copy mb4 pv3">
  /* this will be aligned to the left */
  <div>
    <a>Hypered</a>
  </div>

  /* this will be aligned to the right */
  <div>
    <a>Blog</a>
    <a>Not-os</a>
  </div>
</nav>
```