### PR TITLE
Add pull quote variants

### DIFF
--- a/components/BlockQuote/BlockQuote.js
+++ b/components/BlockQuote/BlockQuote.js
@@ -1,5 +1,16 @@
+import React from "react";
+import cx from "classnames";
+
 export const BlockQuote = props => (
-  <blockquote className="db bl bw2 pv2 ph3 ml0 mv4">
+  <blockquote className="db bl bw2 pv2 ph3 ml0 mv4 lh-copy">
     <span className="i">{props.children}</span>
   </blockquote>
 );
+
+export const PullQuote = props => {
+  return (
+    <blockquote className="pull-quote relative db pv3 ph4 f4 ml0 mv4 lh-copy">
+      <span className="i">{props.children}</span>
+    </blockquote>
+  );
+};

--- a/components/BlockQuote/BlockQuote.js
+++ b/components/BlockQuote/BlockQuote.js
@@ -8,8 +8,21 @@ export const BlockQuote = props => (
 );
 
 export const PullQuote = props => {
+  let pullQuoteClassNames = cx(
+    {
+      "pull-quote": !props.hideQuote,
+    },
+    "relative",
+    "db",
+    "pv3",
+    "ph4",
+    "f4",
+    "ml0",
+    "mv4",
+    "lh-copy",
+  );
   return (
-    <blockquote className="pull-quote relative db pv3 ph4 f4 ml0 mv4 lh-copy">
+    <blockquote className={pullQuoteClassNames}>
       <span className="i">{props.children}</span>
     </blockquote>
   );

--- a/components/BlockQuote/BlockQuote.stories.js
+++ b/components/BlockQuote/BlockQuote.stories.js
@@ -20,3 +20,12 @@ export const PullQuoteExample = () => (
     volutpat dignissim, eros eros sodales quam, a suscipit felis eros non dolor.
   </PullQuote>
 );
+
+export const WithOptionalPullQuoteExample = () => (
+  <PullQuote hideQuote>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam consectetur
+    tincidunt elit, et semper enim laoreet eu. In hac habitasse platea dictumst.
+    Phasellus consequat quis augue vitae laoreet. In consequat, urna vel
+    volutpat dignissim, eros eros sodales quam, a suscipit felis eros non dolor.
+  </PullQuote>
+);

--- a/components/BlockQuote/BlockQuote.stories.js
+++ b/components/BlockQuote/BlockQuote.stories.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { BlockQuote } from "../../components";
+import { BlockQuote, PullQuote } from "../../components";
 
 export default {
   title: "Block Quote",
@@ -10,4 +10,13 @@ export const Default = () => (
     You have power over your mind - not outside events. Realize this, and you
     will find strength.
   </BlockQuote>
+);
+
+export const PullQuoteExample = () => (
+  <PullQuote>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam consectetur
+    tincidunt elit, et semper enim laoreet eu. In hac habitasse platea dictumst.
+    Phasellus consequat quis augue vitae laoreet. In consequat, urna vel
+    volutpat dignissim, eros eros sodales quam, a suscipit felis eros non dolor.
+  </PullQuote>
 );

--- a/components/Layout/BlogPostLayout.js
+++ b/components/Layout/BlogPostLayout.js
@@ -10,6 +10,7 @@ import {
   P,
   Code,
   BlockQuote,
+  PullQuote,
   Divider,
   NavBlockWrapper,
   SidebarTitle,
@@ -72,6 +73,11 @@ export const BlogPostLayout = props => (
         </BlockQuote>
 
         <H3>Ending points</H3>
+
+        <PullQuote>
+          To follow along, you can clone the Git repository and run each
+          nix-build command as they appear at the top of each page.
+        </PullQuote>
 
         <P>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do

--- a/components/Layout/WithSidebarLayout.js
+++ b/components/Layout/WithSidebarLayout.js
@@ -15,6 +15,7 @@ import {
   H4,
   P,
   BlockQuote,
+  PullQuote,
   Divider,
 } from "../../components";
 
@@ -65,6 +66,11 @@ export const WithSidebarLayout = props => (
         </BlockQuote>
 
         <H3>Ending points</H3>
+
+        <PullQuote>
+          To follow along, you can clone the Git repository and run each
+          nix-build command as they appear at the top of each page.
+        </PullQuote>
 
         <P>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -55,3 +55,29 @@
   outline: none;
   z-index: 0;
 }
+
+.pull-quote {
+  position: relative;
+}
+
+.pull-quote:before {
+  content: "“";
+  position: absolute;
+  top: -2rem;
+  left: 0;
+  font-size: 5rem;
+  font-weight: bold;
+  z-index: -1;
+  opacity: 30%;
+}
+
+.pull-quote:after {
+  content: "„";
+  position: absolute;
+  right: 0;
+  bottom: -2rem;
+  font-size: 5rem;
+  font-weight: bold;
+  z-index: -1;
+  opacity: 30%;
+}


### PR DESCRIPTION
Reference issue: https://github.com/hypered/design-system/issues/28

This PR adds one (or more) Pull Quote examples. Right now this is what it looks like:
![Screenshot 2019-12-18 at 12 32 52](https://user-images.githubusercontent.com/278293/71055945-91022480-2192-11ea-8b87-f2befdcf1e19.png)

Would you like to see a few more variants here? @noteed 

Edit: I'll only regenerate the docs when the PR is good to go. :)