### PR TITLE
Add overflow-auto to prevent margins from collapsing

### DIFF
--- a/components/Layout/BlogPostLayout.js
+++ b/components/Layout/BlogPostLayout.js
@@ -21,7 +21,7 @@ import {
 export const BlogPostLayout = props => (
   <Layout>
     <main>
-      <article className="mw7">
+      <article className="mw7 overflow-auto">
         <div className="mb4">
           <H1>Starting with NixOps (and thus Nix and NixOS)</H1>
           <Divider />

--- a/components/Layout/WithSidebarLayout.js
+++ b/components/Layout/WithSidebarLayout.js
@@ -23,7 +23,7 @@ export const WithSidebarLayout = props => (
     <main className="flex flex-wrap nl3 nr3">
       <Sidebar />
 
-      <article className="order-0 order-1-m order-1-l w-100 m-60-m w-60-l ph3">
+      <article className="order-0 order-1-m order-1-l w-100 m-60-m w-60-l ph3 overflow-auto">
         <div className="mb4">
           <H1>Starting with NixOps (and thus Nix and NixOS)</H1>
           <Divider />


### PR DESCRIPTION
Original issue: https://github.com/hypered/design-system/issues/17

Fixes misalignment of `<article>` title in examples where one example has `display: flex;` while the other does not.

PS: docs will not be re-generated until this everything is finalized.