### PR TITLE
Update Table to include styles from sprint-2

### DIFF
--- a/components/Table/Table.js
+++ b/components/Table/Table.js
@@ -1,4 +1,5 @@
 import React from "react";
+import cx from "classnames";
 
 export const Table = props => (
   <div className="overflow-x-scroll">
@@ -8,18 +9,61 @@ export const Table = props => (
   </div>
 );
 
-export const TH1 = props => (
-  <th className="tl bb pa2 fw6 nowrap">{props.children}</th>
-);
+export const TH = ({ size, align, children }) => {
+  let thClassNames = cx(
+    "tl",
+    "bb",
+    "bw1",
+    "fw6",
+    "nowrap",
+    {
+      f5: size === "normal" || !size,
+      pa2: size === "normal" || !size,
+      "b--black": size === "normal" || !size
+    },
+    {
+      f6: size === "compact",
+      pa1: size === "compact",
+      "b--silver": size === "compact"
+    },
+    {
+      tl: align === "left" || !align,
+      tr: align === "right",
+      tc: align === "center"
+    }
+  );
 
-export const TH2 = props => (
-  <th className="tl bb pa1 fw6 f6 nowrap">{props.children}</th>
-);
+  return (
+    <th className={thClassNames} size={size} align={align}>
+      {children}
+    </th>
+  );
+};
 
-export const TD1 = props => (
-  <td className="bb b--black pa2 nowrap">{props.children}</td>
-);
+export const TD = ({ size, align, children }) => {
+  let tdClassNames = cx(
+    "bb",
+    "nowrap",
+    {
+      f5: size === "normal" || !size,
+      pa2: size === "normal" || !size,
+      "b--black": size === "normal" || size
+    },
+    {
+      f6: size === "compact",
+      pa1: size === "compact",
+      "b--silver": size === "compact"
+    },
+    {
+      tl: align === "left" || !align,
+      tr: align === "right",
+      tc: align === "center"
+    }
+  );
 
-export const TD2 = props => (
-  <td className="bb b--silver pa1 f6 nowrap">{props.children}</td>
-);
+  return (
+    <td className={tdClassNames} size={size} align={align}>
+      {children}
+    </td>
+  );
+};

--- a/components/Table/Table.js
+++ b/components/Table/Table.js
@@ -1,11 +1,9 @@
 import React from "react";
 import cx from "classnames";
 
-export const Table = props => (
+export const Table = ({ children }) => (
   <div className="overflow-x-scroll">
-    <table className="bg-white collapse w-100" style={{ minWidth: "40rem" }}>
-      {props.children}
-    </table>
+    <table className="bg-white collapse w-100">{children}</table>
   </div>
 );
 

--- a/components/Table/Table.js
+++ b/components/Table/Table.js
@@ -7,60 +7,88 @@ export const Table = ({ children }) => (
   </div>
 );
 
-export const TH = ({ size, align, children }) => {
+export const TR = ({ isHeader, size, hideBottomBorder, children }) => {
+  let trClassNames = cx("b--black", {
+    bw1: isHeader,
+    bb: !hideBottomBorder,
+    "b--black": size === "normal" || !size,
+    "b--silver": size === "compact"
+  });
+  return (
+    <tr
+      className={trClassNames}
+      isHeader={isHeader}
+      size={size}
+      hideBottomBorder={hideBottomBorder}
+    >
+      {children}
+    </tr>
+  );
+};
+
+export const TH = ({ size, align, colDivider, children }) => {
   let thClassNames = cx(
     "tl",
-    "bb",
-    "bw1",
     "fw6",
     "nowrap",
     {
       f5: size === "normal" || !size,
-      pa2: size === "normal" || !size,
-      "b--black": size === "normal" || !size
+      pa2: size === "normal" || !size
     },
     {
       f6: size === "compact",
-      pa1: size === "compact",
-      "b--silver": size === "compact"
+      pa1: size === "compact"
     },
     {
       tl: align === "left" || !align,
       tr: align === "right",
       tc: align === "center"
+    },
+    {
+      br: colDivider
     }
   );
 
   return (
-    <th className={thClassNames} size={size} align={align}>
+    <th
+      className={thClassNames}
+      size={size}
+      align={align}
+      colDivider={colDivider}
+    >
       {children}
     </th>
   );
 };
 
-export const TD = ({ size, align, children }) => {
+export const TD = ({ size, align, colDivider, children }) => {
   let tdClassNames = cx(
-    "bb",
     "nowrap",
     {
       f5: size === "normal" || !size,
-      pa2: size === "normal" || !size,
-      "b--black": size === "normal" || size
+      pa2: size === "normal" || !size
     },
     {
       f6: size === "compact",
-      pa1: size === "compact",
-      "b--silver": size === "compact"
+      pa1: size === "compact"
     },
     {
       tl: align === "left" || !align,
       tr: align === "right",
       tc: align === "center"
+    },
+    {
+      br: colDivider
     }
   );
 
   return (
-    <td className={tdClassNames} size={size} align={align}>
+    <td
+      className={tdClassNames}
+      size={size}
+      align={align}
+      colDivider={colDivider}
+    >
       {children}
     </td>
   );

--- a/components/Table/Table.stories.js
+++ b/components/Table/Table.stories.js
@@ -1,4 +1,4 @@
-import { Table, TH, TD } from "../../components";
+import { Table, TR, TH, TD } from "../../components";
 
 export default {
   title: "Table"
@@ -6,56 +6,70 @@ export default {
 
 const _rows = 10;
 
-export const Default = () => (
+const TableTemplate = ({ isHeader, size, colDivider, align }) => (
   <Table>
     <thead>
-      <tr>
-        <TH>Column 1</TH>
-        <TH>Column 2</TH>
-        <TH>Column 3</TH>
-        <TH>Column 4</TH>
-        <TH align="right">Column 5</TH>
-      </tr>
+      <TR isHeader>
+        <TH size={size} colDivider={colDivider}>
+          Column 1
+        </TH>
+        <TH size={size} colDivider={colDivider}>
+          Column 2
+        </TH>
+        <TH size={size} colDivider={colDivider}>
+          Column 3
+        </TH>
+        <TH size={size} colDivider={colDivider}>
+          Column 4
+        </TH>
+        <TH size={size} align={"right"}>
+          Column 5
+        </TH>
+      </TR>
     </thead>
+
     <tbody>
-      {[...Array(_rows)].map((row, i) => (
-        <tr key={i}>
-          <TD>Red</TD>
-          <TD>Green</TD>
-          <TD>Blue</TD>
-          <TD>Yellow</TD>
-          <TD align="right">001</TD>
-        </tr>
-      ))}
+      {[...Array(_rows)].map((row, i, arr) => {
+        let hideBottomBorder;
+        if (colDivider) {
+          if (arr.length === i + 1) {
+            hideBottomBorder = true;
+          } else {
+            hideBottomBorder = false;
+          }
+        }
+        return (
+          <TR key={i} hideBottomBorder={hideBottomBorder}>
+            <TD size={size} colDivider={colDivider}>
+              Red
+            </TD>
+            <TD size={size} colDivider={colDivider}>
+              Green
+            </TD>
+            <TD size={size} colDivider={colDivider}>
+              Blue
+            </TD>
+            <TD size={size} colDivider={colDivider}>
+              Yellow
+            </TD>
+            <TD size={size} align="right">
+              001
+            </TD>
+          </TR>
+        );
+      })}
     </tbody>
   </Table>
 );
 
-export const Compact = () => (
-  <Table>
-    <thead>
-      <tr>
-        <TH size="compact">Column 1</TH>
-        <TH size="compact">Column 2</TH>
-        <TH size="compact">Column 3</TH>
-        <TH size="compact">Column 4</TH>
-        <TH size="compact" align="right">
-          Column 5
-        </TH>
-      </tr>
-    </thead>
-    <tbody>
-      {[...Array(_rows)].map((row, i) => (
-        <tr key={i}>
-          <TD size="compact">Red</TD>
-          <TD size="compact">Green</TD>
-          <TD size="compact">Blue</TD>
-          <TD size="compact">Yellow</TD>
-          <TD size="compact" align="right">
-            001
-          </TD>
-        </tr>
-      ))}
-    </tbody>
-  </Table>
+export const Default = () => <TableTemplate size="normal" />;
+
+export const Compact = () => <TableTemplate size="compact" />;
+
+export const WithColumnDivider = () => (
+  <TableTemplate size="normal" colDivider />
+);
+
+export const WithColumnDividerCompact = () => (
+  <TableTemplate size="compact" colDivider />
 );

--- a/components/Table/Table.stories.js
+++ b/components/Table/Table.stories.js
@@ -1,7 +1,7 @@
-import { Table, TH1, TH2, TD1, TD2 } from "../../components";
+import { Table, TH, TD } from "../../components";
 
 export default {
-  title: "Table",
+  title: "Table"
 };
 
 const _rows = 10;
@@ -10,25 +10,21 @@ export const Default = () => (
   <Table>
     <thead>
       <tr>
-        <TH1>Column 1</TH1>
-        <TH1>Column 2</TH1>
-        <TH1>Column 3</TH1>
-        <TH1>Column 4</TH1>
-        <TH1>
-          <div className="tr">Column 5</div>
-        </TH1>
+        <TH>Column 1</TH>
+        <TH>Column 2</TH>
+        <TH>Column 3</TH>
+        <TH>Column 4</TH>
+        <TH align="right">Column 5</TH>
       </tr>
     </thead>
     <tbody>
       {[...Array(_rows)].map((row, i) => (
         <tr key={i}>
-          <TD1>Red</TD1>
-          <TD1>Green</TD1>
-          <TD1>Blue</TD1>
-          <TD1>Yellow</TD1>
-          <TD1>
-            <div className="tr">001</div>
-          </TD1>
+          <TD>Red</TD>
+          <TD>Green</TD>
+          <TD>Blue</TD>
+          <TD>Yellow</TD>
+          <TD align="right">001</TD>
         </tr>
       ))}
     </tbody>
@@ -39,25 +35,25 @@ export const Compact = () => (
   <Table>
     <thead>
       <tr>
-        <TH2>Column 1</TH2>
-        <TH2>Column 2</TH2>
-        <TH2>Column 3</TH2>
-        <TH2>Column 4</TH2>
-        <TH2>
-          <div className="tr">Column 5</div>
-        </TH2>
+        <TH size="compact">Column 1</TH>
+        <TH size="compact">Column 2</TH>
+        <TH size="compact">Column 3</TH>
+        <TH size="compact">Column 4</TH>
+        <TH size="compact" align="right">
+          Column 5
+        </TH>
       </tr>
     </thead>
     <tbody>
       {[...Array(_rows)].map((row, i) => (
         <tr key={i}>
-          <TD2>Red</TD2>
-          <TD2>Green</TD2>
-          <TD2>Blue</TD2>
-          <TD2>Yellow</TD2>
-          <TD2>
-            <div className="tr">001</div>
-          </TD2>
+          <TD size="compact">Red</TD>
+          <TD size="compact">Green</TD>
+          <TD size="compact">Blue</TD>
+          <TD size="compact">Yellow</TD>
+          <TD size="compact" align="right">
+            001
+          </TD>
         </tr>
       ))}
     </tbody>

--- a/components/home/ComponentsSection.js
+++ b/components/home/ComponentsSection.js
@@ -16,8 +16,9 @@ import {
   Code,
   NavBlockWrapper,
   Table,
-  TH2,
-  TD2,
+  TR,
+  TH,
+  TD,
   SidebarTitle,
   SidebarUL,
   SidebarLI,
@@ -35,13 +36,16 @@ import {
   UL,
   LI,
   Input,
-  NavBlock,
+  NavBlock
 } from "../../components";
 
 export const ComponentsSection = props => (
   <Section>
     <div className="flex flex-wrap nl3 nr3">
-      <Gallery title="Buttons" href="../storybook/?path=/story/buttons--primary">
+      <Gallery
+        title="Buttons"
+        href="../storybook/?path=/story/buttons--primary"
+      >
         <div>
           <div className="mb2">
             <Button variant="primary" size="normal">
@@ -56,7 +60,10 @@ export const ComponentsSection = props => (
         </div>
       </Gallery>
 
-      <Gallery title="Link Buttons" href="../storybook/?path=/story/button-link--primary">
+      <Gallery
+        title="Link Buttons"
+        href="../storybook/?path=/story/button-link--primary"
+      >
         <div>
           <div className="mb2">
             <ButtonLink variant="primary" href="#" size="normal">
@@ -149,7 +156,10 @@ export const ComponentsSection = props => (
         </div>
       </Gallery>
 
-      <Gallery title="Code Block" href="../storybook/?path=/story/code-block--code-block">
+      <Gallery
+        title="Code Block"
+        href="../storybook/?path=/story/code-block--code-block"
+      >
         <div className="w-100">
           <Code>{`.tachyons {
   display: block;
@@ -161,52 +171,41 @@ export const ComponentsSection = props => (
         <div className="w-100">
           <Table>
             <thead>
-              <tr>
-                <TH2>Column 1</TH2>
-                <TH2>Column 2</TH2>
-                <TH2>Column 3</TH2>
-                <TH2>Column 4</TH2>
-                <TH2>
-                  <div className="tr">Column 5</div>
-                </TH2>
-              </tr>
+              <TR>
+                <TH>Column 1</TH>
+                <TH>Column 2</TH>
+                <TH>Column 3</TH>
+                <TH>Column 4</TH>
+              </TR>
             </thead>
             <tbody>
-              <tr>
-                <TD2>Red</TD2>
-                <TD2>Green</TD2>
-                <TD2>Blue</TD2>
-                <TD2>Yellow</TD2>
-                <TD2>
-                  <div className="tr">001</div>
-                </TD2>
-              </tr>
-
-              <tr>
-                <TD2>Red</TD2>
-                <TD2>Green</TD2>
-                <TD2>Blue</TD2>
-                <TD2>Yellow</TD2>
-                <TD2>
-                  <div className="tr">001</div>
-                </TD2>
-              </tr>
-
-              <tr>
-                <TD2>Red</TD2>
-                <TD2>Green</TD2>
-                <TD2>Blue</TD2>
-                <TD2>Yellow</TD2>
-                <TD2>
-                  <div className="tr">001</div>
-                </TD2>
-              </tr>
+              <TR>
+                <TD>Red</TD>
+                <TD>Green</TD>
+                <TD>Blue</TD>
+                <TD>Yellow</TD>
+              </TR>
+              <TR>
+                <TD>Red</TD>
+                <TD>Green</TD>
+                <TD>Blue</TD>
+                <TD>Yellow</TD>
+              </TR>
+              <TR>
+                <TD>Red</TD>
+                <TD>Green</TD>
+                <TD>Blue</TD>
+                <TD>Yellow</TD>
+              </TR>
             </tbody>
           </Table>
         </div>
       </Gallery>
 
-      <Gallery title="Heading" href="../storybook/?path=/story/typography--heading-1">
+      <Gallery
+        title="Heading"
+        href="../storybook/?path=/story/typography--heading-1"
+      >
         <div>
           <H1>Heading 1</H1>
           <H2>Heading 2</H2>
@@ -217,7 +216,10 @@ export const ComponentsSection = props => (
         </div>
       </Gallery>
 
-      <Gallery title="Sidebar" href="../storybook/?path=/story/sidebar--default">
+      <Gallery
+        title="Sidebar"
+        href="../storybook/?path=/story/sidebar--default"
+      >
         <div className="w-100">
           <nav>
             <SidebarTitle>Section 1</SidebarTitle>
@@ -262,7 +264,10 @@ export const ComponentsSection = props => (
         </div>
       </Gallery>
 
-      <Gallery title="Paragraph" href="../storybook/?path=/story/typography--paragraph">
+      <Gallery
+        title="Paragraph"
+        href="../storybook/?path=/story/typography--paragraph"
+      >
         <div>
           <H4>Introduction</H4>
           <P>
@@ -272,7 +277,10 @@ export const ComponentsSection = props => (
         </div>
       </Gallery>
 
-      <Gallery title="Blockquote" href="../storybook/?path=/story/typography--paragraph">
+      <Gallery
+        title="Blockquote"
+        href="../storybook/?path=/story/typography--paragraph"
+      >
         <div>
           <BlockQuote>
             You have power over your mind - not outside events. Realize this,
@@ -281,7 +289,10 @@ export const ComponentsSection = props => (
         </div>
       </Gallery>
 
-      <Gallery title="Lists" href="../storybook/?path=/story/list--ordered-list">
+      <Gallery
+        title="Lists"
+        href="../storybook/?path=/story/list--ordered-list"
+      >
         <div>
           <OL>
             <LI>One</LI>
@@ -310,7 +321,10 @@ export const ComponentsSection = props => (
         </div>
       </Gallery>
 
-      <Gallery title="Nav Block" href="../storybook/?path=/story/navigation-block--default">
+      <Gallery
+        title="Nav Block"
+        href="../storybook/?path=/story/navigation-block--default"
+      >
         <div className="w-100">
           <NavBlockWrapper>
             <div className="flex flex-wrap nl3 nr3">
@@ -353,7 +367,10 @@ export const ComponentsSection = props => (
         </div>
       </Gallery>
 
-      <Gallery title="Nav" href="../storybook/?path=/story/navigation--navigation">
+      <Gallery
+        title="Nav"
+        href="../storybook/?path=/story/navigation--navigation"
+      >
         <Nav>
           <div>
             <NavLink active={"true"}>One</NavLink>

--- a/components/home/GalleryPreviewSection.js
+++ b/components/home/GalleryPreviewSection.js
@@ -13,8 +13,9 @@ import {
   Code,
   NavBlockWrapper,
   Table,
-  TH2,
-  TD2,
+  TR,
+  TH,
+  TD,
   SidebarTitle,
   SidebarUL,
   SidebarLI,
@@ -32,7 +33,7 @@ import {
   UL,
   LI,
   Input,
-  NavBlock,
+  NavBlock
 } from "../../components";
 
 export const GalleryPreviewSection = props => (
@@ -74,46 +75,32 @@ export const GalleryPreviewSection = props => (
         <div className="w-100">
           <Table>
             <thead>
-              <tr>
-                <TH2>Column 1</TH2>
-                <TH2>Column 2</TH2>
-                <TH2>Column 3</TH2>
-                <TH2>Column 4</TH2>
-                <TH2>
-                  <div className="tr">Column 5</div>
-                </TH2>
-              </tr>
+              <TR>
+                <TH>Column 1</TH>
+                <TH>Column 2</TH>
+                <TH>Column 3</TH>
+                <TH>Column 4</TH>
+              </TR>
             </thead>
             <tbody>
-              <tr>
-                <TD2>Red</TD2>
-                <TD2>Green</TD2>
-                <TD2>Blue</TD2>
-                <TD2>Yellow</TD2>
-                <TD2>
-                  <div className="tr">001</div>
-                </TD2>
-              </tr>
-
-              <tr>
-                <TD2>Red</TD2>
-                <TD2>Green</TD2>
-                <TD2>Blue</TD2>
-                <TD2>Yellow</TD2>
-                <TD2>
-                  <div className="tr">001</div>
-                </TD2>
-              </tr>
-
-              <tr>
-                <TD2>Red</TD2>
-                <TD2>Green</TD2>
-                <TD2>Blue</TD2>
-                <TD2>Yellow</TD2>
-                <TD2>
-                  <div className="tr">001</div>
-                </TD2>
-              </tr>
+              <TR>
+                <TD>Red</TD>
+                <TD>Green</TD>
+                <TD>Blue</TD>
+                <TD>Yellow</TD>
+              </TR>
+              <TR>
+                <TD>Red</TD>
+                <TD>Green</TD>
+                <TD>Blue</TD>
+                <TD>Yellow</TD>
+              </TR>
+              <TR>
+                <TD>Red</TD>
+                <TD>Green</TD>
+                <TD>Blue</TD>
+                <TD>Yellow</TD>
+              </TR>
             </tbody>
           </Table>
         </div>


### PR DESCRIPTION
- add examples of table with column-dividers
- update Table components to use `classnames`
- clean up repetitive code

**Default:**
![Screenshot 2020-04-23 at 22 41 49](https://user-images.githubusercontent.com/278293/80112495-be813380-85b3-11ea-9983-3fb241951cc1.png)

**Compact:**
![Screenshot 2020-04-23 at 22 42 07](https://user-images.githubusercontent.com/278293/80112505-c0e38d80-85b3-11ea-8cf6-68c8ff973f33.png)

**With Column Dividers**
![Screenshot 2020-04-24 at 00 36 09](https://user-images.githubusercontent.com/278293/80125038-b03b1380-85c3-11ea-8267-c99a6949210b.png)

**With Column Dividers (Compact)**
![Screenshot 2020-04-24 at 00 36 25](https://user-images.githubusercontent.com/278293/80125043-b16c4080-85c3-11ea-9a01-7924fb89bcfb.png)
