### PR TITLE
Add status-code component and pages (wip)

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,15 @@ Pages feature from the `master` branch.
 There is still old examples in the `docs/` directory.
 
 
+## Maintainers
+
+Thu: when I have a PR from Andy to review, I:
+
+- `git fetch --all` (all, otherwise the `andyngo` remote is not fetched)
+- git checkout the branch (without the `andyngo:` prefix display on the PR)
+- `./upload-to-entrypoint.sh` then it is visible on my local server
+
+
 ## Elsewhere
 
 - The [IBM design system](https://www.carbondesignsystem.com/) is open source.

--- a/components/ContainerWithLabel/ContainerWithLabel.js
+++ b/components/ContainerWithLabel/ContainerWithLabel.js
@@ -1,0 +1,10 @@
+import React from "react";
+
+export const ContainerWithLabel = ({ label, children }) => {
+  return (
+    <div>
+      <label className="dib bg-red white f6 mv0 pv1 ph2">{label}</label>
+      <div className="ba b--red debug-grid-16">{children}</div>
+    </div>
+  );
+};

--- a/components/ContainerWithLabel/ContainerWithLabel.stories.js
+++ b/components/ContainerWithLabel/ContainerWithLabel.stories.js
@@ -1,0 +1,26 @@
+import React from "react";
+import { ContainerWithLabel } from "../../components";
+
+export default {
+  title: "Container With Label"
+};
+
+export const Default = () => {
+  return (
+    <div className="pa6 mw7 center">
+      <ContainerWithLabel label="Warning!">
+        <div className="aspect-ratio aspect-ratio--3x4 relative">
+          <div className="aspect-ratio--object pa4">
+            <h2 className="f-headline fw9 tracked-tight lh-title mv3">
+              Error 50x
+            </h2>
+            <p className="f5 lh-copy mv3">
+              Looks like the page that you're looking for is not available.
+              Please click here to return to the home page.
+            </p>
+          </div>
+        </div>
+      </ContainerWithLabel>
+    </div>
+  );
+};

--- a/components/StatusCode/StatusCode.js
+++ b/components/StatusCode/StatusCode.js
@@ -1,0 +1,19 @@
+import React from "react";
+import { ContainerWithLabel } from "../../components";
+
+export const StatusCode = ({ status, statusCode, children }) => {
+  return (
+    <ContainerWithLabel label="Status">
+      <div className="pa5">
+        <h2 className="red f3 fw8 tracked-tight lh-title mv3 ttu">Error</h2>
+        <h3
+          className="glitch f1 f-headline-m f-headline-l fw9 tracked-tight lh-title mv3"
+          data-text={`${statusCode} ${status}`}
+        >
+          {statusCode} {status}
+        </h3>
+        <div>{children}</div>
+      </div>
+    </ContainerWithLabel>
+  );
+};

--- a/components/StatusCode/StatusCode.js
+++ b/components/StatusCode/StatusCode.js
@@ -1,13 +1,13 @@
 import React from "react";
-import { ContainerWithLabel } from "../../components";
+import { ContainerWithLabel, P, UL, LI, A } from "../../components";
 
 export const StatusCode = ({ status, statusCode, children }) => {
   return (
     <ContainerWithLabel label="Status">
-      <div className="pa5">
-        <h2 className="red f3 fw8 tracked-tight lh-title mv3 ttu">Error</h2>
+      <div className="pa6">
+        <h2 className="red f4 fw8 tracked-tight lh-title mv0 ttu">Error</h2>
         <h3
-          className="glitch f1 f-subheadline-m f-subheadline-l fw9 tracked-tight lh-title mv3"
+          className="glitch f1 f-subheadline-m f-subheadline-l fw9 tracked-tight lh-title mv0"
           data-text={`${statusCode} ${status}`}
         >
           {statusCode} {status}
@@ -15,5 +15,50 @@ export const StatusCode = ({ status, statusCode, children }) => {
         <div>{children}</div>
       </div>
     </ContainerWithLabel>
+  );
+};
+
+const Custom404Content = () => {
+  return (
+    <div>
+      <P>
+        Looks like the page you're looking for is unavailable. You can click
+        here to return to the home page, or visit any of the links below:
+      </P>
+
+      <UL>
+        <LI>
+          <A href="/">Home</A>
+        </LI>
+        <LI>
+          <A href="components/">Components</A>
+        </LI>
+        <LI>
+          <A href="storybook/">Storybook</A>
+        </LI>
+        <LI>
+          <A href="documentation/">Documentation</A>
+        </LI>
+        <LI>
+          <A href="haddock/">Haddock</A>
+        </LI>
+      </UL>
+    </div>
+  );
+};
+
+export const Custom400 = () => {
+  return (
+    <StatusCode status="Bad Gateway" statusCode="400">
+      <Custom404Content />
+    </StatusCode>
+  );
+};
+
+export const Custom404 = () => {
+  return (
+    <StatusCode status="Not Found" statusCode="404">
+      <Custom404Content />
+    </StatusCode>
   );
 };

--- a/components/StatusCode/StatusCode.js
+++ b/components/StatusCode/StatusCode.js
@@ -7,7 +7,7 @@ export const StatusCode = ({ status, statusCode, children }) => {
       <div className="pa5">
         <h2 className="red f3 fw8 tracked-tight lh-title mv3 ttu">Error</h2>
         <h3
-          className="glitch f1 f-headline-m f-headline-l fw9 tracked-tight lh-title mv3"
+          className="glitch f1 f-subheadline-m f-subheadline-l fw9 tracked-tight lh-title mv3"
           data-text={`${statusCode} ${status}`}
         >
           {statusCode} {status}

--- a/components/StatusCode/StatusCode.stories.js
+++ b/components/StatusCode/StatusCode.stories.js
@@ -1,0 +1,62 @@
+import React from "react";
+import { StatusCode, P, UL, LI, A } from "../../components";
+
+export default {
+  title: "Status Codes"
+};
+
+const NotFoundContent = () => {
+  return (
+    <div>
+      <P>
+        Looks like the page you're looking for is unavailable. You can click
+        here to return to the home page, or visit any of the links below:
+      </P>
+      <UL>
+        <LI>
+          <A href="/">Home</A>
+        </LI>
+        <LI>
+          <A href="components/">Components</A>
+        </LI>
+        <LI>
+          <A href="storybook/">Storybook</A>
+        </LI>
+        <LI>
+          <A href="documentation/">Documentation</A>
+        </LI>
+        <LI>
+          <A href="haddock/">Haddock</A>
+        </LI>
+      </UL>
+    </div>
+  );
+};
+
+const Container = ({ children }) => {
+  return (
+    <div className="flex items-center justify-center vh-100 mw7 center pa4">
+      {children}
+    </div>
+  );
+};
+
+export const BadGateway = () => {
+  return (
+    <Container>
+      <StatusCode status="Bad Gateway" statusCode="400">
+        <NotFoundContent />
+      </StatusCode>
+    </Container>
+  );
+};
+
+export const NotFound = () => {
+  return (
+    <Container>
+      <StatusCode status="Not Found" statusCode="404">
+        <NotFoundContent />
+      </StatusCode>
+    </Container>
+  );
+};

--- a/components/StatusCode/StatusCode.stories.js
+++ b/components/StatusCode/StatusCode.stories.js
@@ -1,62 +1,30 @@
 import React from "react";
-import { StatusCode, P, UL, LI, A } from "../../components";
+import { Custom400, Custom404 } from "../../components";
 
 export default {
   title: "Status Codes"
 };
 
-const NotFoundContent = () => {
-  return (
-    <div>
-      <P>
-        Looks like the page you're looking for is unavailable. You can click
-        here to return to the home page, or visit any of the links below:
-      </P>
-      <UL>
-        <LI>
-          <A href="/">Home</A>
-        </LI>
-        <LI>
-          <A href="components/">Components</A>
-        </LI>
-        <LI>
-          <A href="storybook/">Storybook</A>
-        </LI>
-        <LI>
-          <A href="documentation/">Documentation</A>
-        </LI>
-        <LI>
-          <A href="haddock/">Haddock</A>
-        </LI>
-      </UL>
-    </div>
-  );
-};
-
 const Container = ({ children }) => {
   return (
-    <div className="flex items-center justify-center vh-100 mw7 center pa4">
+    <div className="flex items-center justify-center vh-100 mw8 center pa4">
       {children}
     </div>
   );
 };
 
-export const BadGateway = () => {
+export const Error400 = () => {
   return (
     <Container>
-      <StatusCode status="Bad Gateway" statusCode="400">
-        <NotFoundContent />
-      </StatusCode>
+      <Custom400 />
     </Container>
   );
 };
 
-export const NotFound = () => {
+export const Error404 = () => {
   return (
     <Container>
-      <StatusCode status="Not Found" statusCode="404">
-        <NotFoundContent />
-      </StatusCode>
+      <Custom404 />
     </Container>
   );
 };

--- a/components/Whitespace/Whitespace.stories.js
+++ b/components/Whitespace/Whitespace.stories.js
@@ -1,8 +1,8 @@
 import React from "react";
-import { Layout } from "../../components";
+import { Layout, ContainerWithLabel } from "../../components";
 
 export default {
-  title: "Whitespace",
+  title: "Whitespace"
 };
 
 const Box = ({ title, description }) => {
@@ -64,12 +64,11 @@ export const FullWidth = () => {
 export const Examples = () => {
   return (
     <Layout>
-      <h1 className="dib bg-red white f6 mv0 pv1 ph2">Container</h1>
-      <div className="ba b--red debug-grid-16">
+      <ContainerWithLabel label="Container">
         <AutoWidth />
         <NegativeMargins />
         <FullWidth />
-      </div>
+      </ContainerWithLabel>
     </Layout>
   );
 };

--- a/components/index.js
+++ b/components/index.js
@@ -20,6 +20,7 @@ export * from "./List/List";
 export * from "./HR/HR";
 export * from "./Image/Image";
 export * from "./ContainerWithLabel/ContainerWithLabel";
+export * from "./StatusCode/StatusCode";
 export * from "./Footer/Footer";
 
 export * from "./home/NavSection";

--- a/components/index.js
+++ b/components/index.js
@@ -19,6 +19,7 @@ export * from "./BlockQuote/BlockQuote";
 export * from "./List/List";
 export * from "./HR/HR";
 export * from "./Image/Image";
+export * from "./ContainerWithLabel/ContainerWithLabel";
 export * from "./Footer/Footer";
 
 export * from "./home/NavSection";

--- a/pages/404.js
+++ b/pages/404.js
@@ -1,0 +1,17 @@
+import React from "react";
+
+import { HomeLayout, HeaderSection, StatusCode } from "../components";
+
+function Home() {
+  return (
+    <HomeLayout>
+      <div className="mw7 center">
+        <StatusCode status="Not Found" statusCode="404">
+          testing
+        </StatusCode>
+      </div>
+    </HomeLayout>
+  );
+}
+
+export default Home;

--- a/pages/404.js
+++ b/pages/404.js
@@ -1,17 +1,22 @@
 import React from "react";
 
-import { HomeLayout, HeaderSection, StatusCode } from "../components";
+import { HomeLayout, Custom404 } from "../components";
 
-function Home() {
+{
+  /*
+  this file is statically generated at build time:
+  https://nextjs.org/docs/advanced-features/custom-error-page#404-page
+  */
+}
+
+function Error404() {
   return (
     <HomeLayout>
-      <div className="mw7 center">
-        <StatusCode status="Not Found" statusCode="404">
-          testing
-        </StatusCode>
+      <div className="mw8 center">
+        <Custom404 status="Not Found" statusCode="404" />
       </div>
     </HomeLayout>
   );
 }
 
-export default Home;
+export default Error404;

--- a/pages/_error.js
+++ b/pages/_error.js
@@ -6,7 +6,11 @@ function Error({ statusCode }) {
   return (
     <HomeLayout>
       <div className="mw8 center">
-        <StatusCode status="Bad Gateway" statusCode="400"></StatusCode>
+        <StatusCode status="Error" statusCode={statusCode}>
+          {statusCode
+            ? `An error ${statusCode} occured on server`
+            : `An error occured on client`}
+        </StatusCode>
       </div>
     </HomeLayout>
   );

--- a/pages/_error.js
+++ b/pages/_error.js
@@ -1,0 +1,20 @@
+import React from "react";
+
+import { HomeLayout, StatusCode } from "../components";
+
+function Error({ statusCode }) {
+  return (
+    <HomeLayout>
+      <div className="mw8 center">
+        <StatusCode status="Bad Gateway" statusCode="400"></StatusCode>
+      </div>
+    </HomeLayout>
+  );
+}
+
+Error.getInitialProps = ({ res, err }) => {
+  const statusCode = res ? res.statusCode : err ? err.statusCode : 404;
+  return { statusCode };
+};
+
+export default Error;

--- a/static/css/glitch.css
+++ b/static/css/glitch.css
@@ -1,0 +1,113 @@
+@keyframes glitch-1 {
+  0% {
+    top: -1px;
+    left: -1px;
+  }
+  12.5% {
+    top: 0px;
+    left: 2px;
+  }
+  25% {
+    top: 1px;
+    left: -4px;
+  }
+  37.5% {
+    top: -1px;
+    left: -3px;
+  }
+  50% {
+    top: 3px;
+    left: 4px;
+  }
+  62.5% {
+    top: -3px;
+    left: -2px;
+  }
+  75% {
+    top: -4px;
+    left: 2px;
+  }
+  87.5% {
+    top: -2px;
+    left: 4px;
+  }
+  100% {
+    top: 4px;
+    left: 3px;
+  }
+}
+
+@keyframes glitch-2 {
+  0% {
+    top: 0px;
+    left: 3px;
+  }
+  12.5% {
+    top: -4px;
+    left: 1px;
+  }
+  25% {
+    top: 3px;
+    left: 3px;
+  }
+  37.5% {
+    top: 5px;
+    left: -3px;
+  }
+  50% {
+    top: 1px;
+    left: 2px;
+  }
+  62.5% {
+    top: -3px;
+    left: 0px;
+  }
+  75% {
+    top: 3px;
+    left: 2px;
+  }
+  87.5% {
+    top: -3px;
+    left: -4px;
+  }
+  100% {
+    top: -3px;
+    left: 2px;
+  }
+}
+
+.glitch {
+  position: relative;
+}
+
+.glitch::before,
+.glitch::after {
+  content: attr(data-text);
+  position: absolute;
+}
+
+.glitch::before {
+  display: none;
+  color: rgba(255, 0, 0, 1);
+  top: 2px;
+  left: 2px;
+  z-index: -1;
+}
+
+.glitch::after {
+  display: none;
+  color: rgba(0, 0, 255, 1);
+  top: -2px;
+  left: -2px;
+  z-index: -1;
+}
+
+.glitch:hover::before {
+  display: block;
+  animation: glitch-1 1s infinite steps(2) alternate-reverse;
+}
+
+.glitch:hover::after {
+  display: block;
+  animation: glitch-2 1s infinite steps(2) alternate-reverse;
+}

--- a/static/css/glitch.css
+++ b/static/css/glitch.css
@@ -1,78 +1,62 @@
+
 @keyframes glitch-1 {
   0% {
-    top: -1px;
-    left: -1px;
+    opacity: 1;
+    transform: scaleX(1.0329162778) scaleY(0.9624880521);
   }
   12.5% {
-    top: 0px;
-    left: 2px;
+    transform: scaleX(0.9594370913) scaleY(0.9506424701);
   }
   25% {
-    top: 1px;
-    left: -4px;
+    transform: scaleX(0.9609167887) scaleY(0.9939509189);
   }
   37.5% {
-    top: -1px;
-    left: -3px;
+    transform: scaleX(0.9748098798) scaleY(1.016507008);
   }
   50% {
-    top: 3px;
-    left: 4px;
+    transform: scaleX(1.0090070602) scaleY(1.0293011137);
   }
   62.5% {
-    top: -3px;
-    left: -2px;
+    transform: scaleX(1.011470297) scaleY(0.9798958466);
   }
   75% {
-    top: -4px;
-    left: 2px;
+    transform: scaleX(1.0139757613) scaleY(1.0132142825);
   }
   87.5% {
-    top: -2px;
-    left: 4px;
+    transform: scaleX(0.9966595719) scaleY(0.9653377351);
   }
   100% {
-    top: 4px;
-    left: 3px;
+    transform: scaleX(1.0107728028) scaleY(1.0299823559);
   }
 }
-
 @keyframes glitch-2 {
   0% {
-    top: 0px;
-    left: 3px;
+    opacity: 1;
+    transform: scaleX(1.0153638162) scaleY(0.9589924759);
   }
   12.5% {
-    top: -4px;
-    left: 1px;
+    transform: scaleX(1.0129333274) scaleY(0.9706429895);
   }
   25% {
-    top: 3px;
-    left: 3px;
+    transform: scaleX(1.0490139047) scaleY(0.9530988471);
   }
   37.5% {
-    top: 5px;
-    left: -3px;
+    transform: scaleX(1.0294264153) scaleY(1.0011773602);
   }
   50% {
-    top: 1px;
-    left: 2px;
+    transform: scaleX(1.0165361213) scaleY(1.0161648472);
   }
   62.5% {
-    top: -3px;
-    left: 0px;
+    transform: scaleX(0.9536013452) scaleY(1.0382458113);
   }
   75% {
-    top: 3px;
-    left: 2px;
+    transform: scaleX(1.0189016142) scaleY(1.0006529632);
   }
   87.5% {
-    top: -3px;
-    left: -4px;
+    transform: scaleX(0.9682949246) scaleY(1.0070691552);
   }
   100% {
-    top: -3px;
-    left: 2px;
+    transform: scaleX(0.9824294528) scaleY(0.9930084328);
   }
 }
 
@@ -84,22 +68,25 @@
 .glitch::after {
   content: attr(data-text);
   position: absolute;
+  transform-origin: (50% 50%);
 }
 
 .glitch::before {
-  display: none;
+  opacity: 0;
   color: rgba(255, 0, 0, 1);
   top: 2px;
   left: 2px;
   z-index: -1;
+  animation: glitch-1 1s steps(2) alternate-reverse;
 }
 
 .glitch::after {
-  display: none;
+  opacity: 0;
   color: rgba(0, 0, 255, 1);
   top: -2px;
   left: -2px;
   z-index: -1;
+  animation: glitch-2 1s steps(2) alternate-reverse;
 }
 
 .glitch:hover::before {

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1,4 +1,5 @@
 @import url("https://rsms.me/inter/inter.css");
+@import url("./glitch.css");
 
 /* colours - text */
 


### PR DESCRIPTION
- [ ] Add 404, 50x, common error pages
- [ ] Improve design

The status code page/component looks something like this at the moment:
![Screenshot 2020-04-25 at 01 00 07](https://user-images.githubusercontent.com/278293/80237956-27d67480-8690-11ea-963c-a279fc7fcb76.png)
